### PR TITLE
Fix for newer Rust versions and Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 log.txt
 tmp
+/.idea

--- a/src/board.rs
+++ b/src/board.rs
@@ -42,7 +42,7 @@ impl Board {
     }
 
     pub fn make(&mut self, mv: Move) {
-        let state = self.position.state().clone();
+        let state = *self.position.state();
         let key = self.position.hash_key();
         let captured = self.position.make(mv);
 

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -2,7 +2,7 @@ use side::Side;
 use square::*;
 use std::fmt;
 
-/// Represents a castleove
+/// Represents a castle move
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
 pub struct Castle(pub usize);
 

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -159,7 +159,7 @@ pub fn loud_legal_moves_with_preprocessing<L: MoveAdder>(
     let stm = position.state().stm;
     let kings = position.bb_pc(KING.pc(stm));
 
-    // We always need legal king movess
+    // We always need legal king moves
     let attacked_squares = king_danger_squares(kings, stm.flip(), position);
 
     let king_sq = kings.bitscan();

--- a/src/gen/slider/ray_bmi2/gen.rs
+++ b/src/gen/slider/ray_bmi2/gen.rs
@@ -10,7 +10,7 @@ pub fn generate_offsets() {
   let mut offset = 0;
 
   println!("use bb::BB;");
-  println!("");
+  println!();
   println!("pub struct Offset {{");
   println!("    pub inner_mask: BB,");
   println!("    pub outer_mask: BB,");

--- a/src/gen/slider/ray_hyperbola.rs
+++ b/src/gen/slider/ray_hyperbola.rs
@@ -89,7 +89,7 @@ pub fn bishop_attacks_from_sq(from: Square, occupied_bb: BB) -> BB {
         let ret = (forward_targets ^ backward_targets) & masks;
 
         let (high, low) = ret.extract();
-        return high | low;
+        high | low
     }
 }
 

--- a/src/gen/slider/ray_kogge_stone.rs
+++ b/src/gen/slider/ray_kogge_stone.rs
@@ -1,5 +1,5 @@
 // loop-based sliding piece attacks
-// efficient for pinned pieces and calculating multiple sliders simulataneously
+// efficient for pinned pieces and calculating multiple sliders simultaneously
 
 use bb::*;
 use square::Square;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 
 #![feature(test)]
 #![feature(platform_intrinsics)]
-#![feature(const_fn)]
 #![feature(binary_heap_into_iter_sorted)]
 
 pub mod bb;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 #![feature(platform_intrinsics)]
-#![feature(const_fn)]
 #![feature(binary_heap_into_iter_sorted)]
 
 pub mod bb;

--- a/src/mv_list/sorted_move_adder.rs
+++ b/src/mv_list/sorted_move_adder.rs
@@ -367,7 +367,7 @@ impl Eq for SortedMoveHeapItem {}
 
 impl PartialOrd for SortedMoveHeapItem {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.ordering_score().partial_cmp(&other.ordering_score())
+        self.ordering_score().partial_cmp(other.ordering_score())
     }
 }
 

--- a/src/mv_list/sorted_move_adder.rs
+++ b/src/mv_list/sorted_move_adder.rs
@@ -14,15 +14,15 @@ use std::fmt;
 /// SortedMoveAdder collects moves including the piece-square score for making the move
 /// Moves are sorted by an 'ordering score' and stored in a provided SortedMoveHeap
 ///     
-/// Non-captures are ordered by priotising destination squares that are
+/// Non-captures are ordered by prioritising destination squares that are
 /// further up the board relative to the mover, with a bonus for pawns
 /// near promotion, a handicap for non-pawn moves to rank 1, and a handicap
 /// for pawn moves to low ranks.
 ///
-/// Captures are ordered by most-valuable-victim / least-valuable-aggresor
+/// Captures are ordered by most-valuable-victim / least-valuable-aggressor
 /// with piece scores worth:
 ///     Pawn: 0
-///     King: 1 (can only be aggresor)
+///     King: 1 (can only be aggressor)
 ///     Knight: 2
 ///     Bishop: 3
 ///     Rook: 4

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -37,7 +37,7 @@ pub fn perft(
   let (tx, rx) = channel();
 
   let mut moves = MoveVec::new();
-  legal_moves(&position, &mut moves);
+  legal_moves(position, &mut moves);
   let moves_len = moves.len();
 
   for &mv in moves.iter() {
@@ -65,14 +65,14 @@ pub fn perft(
 pub fn perft_inner(position: &mut Position, depth: usize) -> u64 {
   if depth == 1 {
     let mut counter = MoveCounter::new();
-    legal_moves(&position, &mut counter);
+    legal_moves(position, &mut counter);
     return counter.moves;
   }
 
   let mut moves = MoveVec::new();
-  legal_moves(&position, &mut moves);
+  legal_moves(position, &mut moves);
 
-  let state = position.state().clone();
+  let state = *position.state();
   let key = position.hash_key();
   let mut count = 0;
   for &mv in moves.iter() {
@@ -97,13 +97,13 @@ fn perft_with_cache_inner(position: &mut Position, depth: usize, cache: &mut Cac
   let mut count = 0;
   if depth == 1 {
     let mut counter = MoveCounter::new();
-    legal_moves(&position, &mut counter);
+    legal_moves(position, &mut counter);
     count = counter.moves as u64;
   } else {
     let mut moves = MoveVec::new();
-    legal_moves(&position, &mut moves);
+    legal_moves(position, &mut moves);
 
-    let state = position.state().clone();
+    let state = *position.state();
     let key = position.hash_key();
     for &mv in moves.iter() {
       let capture = position.make(mv);
@@ -144,7 +144,7 @@ pub fn perft_detailed(
   let (tx, rx) = channel();
 
   let mut moves = MoveVec::new();
-  legal_moves(&position, &mut moves);
+  legal_moves(position, &mut moves);
   let moves_len = moves.len();
 
   for &mv in moves.iter() {
@@ -173,14 +173,14 @@ pub fn perft_detailed_inner(position: &mut Position, depth: usize) -> MoveCounte
   let mut counter = MoveCounter::new();
 
   if depth == 1 {
-    legal_moves(&position, &mut counter);
+    legal_moves(position, &mut counter);
     return counter;
   }
 
   let mut moves = MoveVec::new();
-  legal_moves(&position, &mut moves);
+  legal_moves(position, &mut moves);
 
-  let state = position.state().clone();
+  let state = *position.state();
   let key = position.hash_key();
   for &mv in moves.iter() {
     let capture = position.make(mv);

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -25,11 +25,11 @@ pub fn perft(
   }
 
   if !multi_threading_enabled {
-    if cache_bytes_per_thread > 0 {
+    return if cache_bytes_per_thread > 0 {
       let mut cache = Cache::new(cache_bytes_per_thread).unwrap();
-      return perft_with_cache_inner(position, depth, &mut cache);
+      perft_with_cache_inner(position, depth, &mut cache)
     } else {
-      return perft_inner(position, depth);
+      perft_inner(position, depth)
     }
   }
 

--- a/src/position/make.rs
+++ b/src/position/make.rs
@@ -21,7 +21,7 @@ impl Position {
         debug_assert_ne!(mv, NULL_MOVE);
 
         let stm = self.state.stm;
-        let initial_state = self.state.clone();
+        let initial_state = self.state;
         let mut move_resets_half_move_clock = false;
 
         // increment full move clock if black moved
@@ -112,7 +112,7 @@ impl Position {
     }
 
     pub fn make_null_move(&mut self) -> Option<(Piece, Square)> {
-        let initial_state = self.state.clone();
+        let initial_state = self.state;
 
         // increment full move clock if black moved
         if self.state.stm == BLACK {
@@ -140,7 +140,7 @@ impl Position {
     ) {
         debug_assert_ne!(mv, NULL_MOVE);
 
-        self.state = original_state.clone();
+        self.state = *original_state;
         self.key = original_hash_key;
 
         if mv.is_castle() {
@@ -175,7 +175,7 @@ impl Position {
     }
 
     pub fn unmake_null_move(&mut self, original_state: &State, original_hash_key: u64) {
-        self.state = original_state.clone();
+        self.state = *original_state;
         self.key = original_hash_key;
     }
 }

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -62,7 +62,7 @@ impl std::clone::Clone for Position {
             grid: self.grid,
             bb_sides: self.bb_sides,
             bb_pieces: self.bb_pieces,
-            state: self.state.clone(),
+            state: self.state,
             key: self.key,
             hash: self.hash,
         }


### PR DESCRIPTION
I went ahead and fixed the project for newer Rust versions since const_fn is no longer possible.
I also removed unnecessary clone calls on structs that implement copy and References that are immediately dereferenced by the compiler